### PR TITLE
upgrade inngest SDK to v3.54.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-unused-imports": "^3.0.0",
         "husky": "^8.0.3",
         "immer": "^10.0.4",
-        "inngest": "^3.52.1",
+        "inngest": "^3.54.0",
         "next": "^14.0.2",
         "partysocket": "1.0.0",
         "prettier": "^3.2.5",
@@ -8244,9 +8244,10 @@
       "license": "ISC"
     },
     "node_modules/inngest": {
-      "version": "3.52.1",
-      "resolved": "https://registry.npmjs.org/inngest/-/inngest-3.52.1.tgz",
-      "integrity": "sha512-QrCIVOnAVtFAOLuqWIpK+/bFQyn0nvD6p0s3+2iFlsmaOB/fKcjbMC/5WXz8yLh0c7cBJLGeJRnCKbhI9cEW7Q==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/inngest/-/inngest-3.54.0.tgz",
+      "integrity": "sha512-EBMgyRZt9rWUmc9GUdxznbO1CmyXKZi2CZPNxNTyZJyjZMXFhPiftq/lTKjhYXD9/WlqaVFVB2K7o8vDAkGs6w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
         "@inngest/ai": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "husky": "^8.0.3",
     "immer": "^10.0.4",
-    "inngest": "^3.52.1",
+    "inngest": "^3.54.0",
     "next": "^14.0.2",
     "partysocket": "1.0.0",
     "prettier": "^3.2.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades the Inngest runtime/SDK used to enqueue and serve background jobs, which could introduce behavioral or compatibility changes at runtime despite the small diff.
> 
> **Overview**
> Upgrades the `inngest` dependency from `^3.52.1` to `^3.54.0` in `package.json`, with corresponding `package-lock.json` updates (new resolved tarball, integrity hash, and license metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e691a354775f7373340dd78619090dc7d7bf7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->