### PR TITLE
Manual video select, metadata and upload error/progress improvements 

### DIFF
--- a/app/api/job/route.ts
+++ b/app/api/job/route.ts
@@ -6,6 +6,18 @@ import { initiateMigration, processVideo, refreshVideoList } from '@/workflows/m
 
 export const dynamic = 'force-dynamic';
 
+async function fetchPartyKitJob(jobId: string): Promise<Response> {
+  const partyKitUrl = process.env.NEXT_PUBLIC_PARTYKIT_URL;
+  if (!partyKitUrl) {
+    throw new Error('NEXT_PUBLIC_PARTYKIT_URL is not configured');
+  }
+
+  return fetch(`${partyKitUrl}/party/${jobId}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 export async function GET(request: Request) {
   return new Response('Hello, World!', { status: 200 });
 }
@@ -16,7 +28,12 @@ export async function POST(request: Request) {
   const run = await start(initiateMigration, [body]);
   const jobId = run.runId;
 
-  await createJob(jobId);
+  try {
+    await createJob(jobId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to initialize migration job';
+    return Response.json({ error: message }, { status: 503 });
+  }
 
   return new Response(JSON.stringify({ id: jobId }), { status: 201 });
 }
@@ -44,6 +61,25 @@ export async function PATCH(request: Request) {
       { error: 'jobId, sourcePlatform, destinationPlatform, and videos are required' },
       { status: 400 }
     );
+  }
+
+  try {
+    const partyKitResponse = await fetchPartyKitJob(body.jobId);
+    if (partyKitResponse.status === 404) {
+      return Response.json(
+        { error: 'Migration job was not found. Restart PartyKit and create a new migration job.' },
+        { status: 409 }
+      );
+    }
+
+    if (!partyKitResponse.ok) {
+      return Response.json(
+        { error: `PartyKit returned ${partyKitResponse.status}. Start PartyKit and retry.` },
+        { status: 503 }
+      );
+    }
+  } catch {
+    return Response.json({ error: 'PartyKit is unavailable. Start PartyKit and retry.' }, { status: 503 });
   }
 
   const runIds: string[] = [];

--- a/app/api/job/route.ts
+++ b/app/api/job/route.ts
@@ -1,7 +1,8 @@
 import { start } from 'workflow/api';
 
 import { createJob } from '@/utils/job';
-import { initiateMigration } from '@/workflows/migration';
+import type { DestinationPlatform, SourcePlatform, Video } from '@/utils/store';
+import { initiateMigration, processVideo, refreshVideoList } from '@/workflows/migration';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,4 +19,38 @@ export async function POST(request: Request) {
   await createJob(jobId);
 
   return new Response(JSON.stringify({ id: jobId }), { status: 201 });
+}
+
+export async function PATCH(request: Request) {
+  const body = (await request.json()) as {
+    action?: 'refresh-videos';
+    jobId?: string;
+    sourcePlatform?: SourcePlatform;
+    destinationPlatform?: DestinationPlatform;
+    videos?: Video[];
+  };
+
+  if (body.action === 'refresh-videos') {
+    if (!body.jobId || !body.sourcePlatform) {
+      return Response.json({ error: 'jobId and sourcePlatform are required to refresh videos' }, { status: 400 });
+    }
+
+    const run = await start(refreshVideoList, [body.jobId, body.sourcePlatform]);
+    return Response.json({ refreshStarted: true, runId: run.runId }, { status: 202 });
+  }
+
+  if (!body.jobId || !body.sourcePlatform || !body.destinationPlatform || !body.videos?.length) {
+    return Response.json(
+      { error: 'jobId, sourcePlatform, destinationPlatform, and videos are required' },
+      { status: 400 }
+    );
+  }
+
+  const runIds: string[] = [];
+  for (const video of body.videos) {
+    const run = await start(processVideo, [body.jobId, body.sourcePlatform, body.destinationPlatform, video]);
+    runIds.push(run.runId);
+  }
+
+  return Response.json({ started: runIds.length, runIds }, { status: 200 });
 }

--- a/app/components/platforms/video-filter.tsx
+++ b/app/components/platforms/video-filter.tsx
@@ -16,19 +16,20 @@ export default function VideoFilter() {
         <button
           className="p-4 border-2 rounded text-slate-600 border-slate-200 hover:border-slate-300 focus:border-slate-300 text-base h-28 w-56"
           onClick={() => {
-            setAssetFilter([]);
+            setAssetFilter(true);
             setCurrentStep('select-destination');
           }}
         >
           Move everything. All of it.
         </button>
         <button
-          disabled
-          className="p-4 border-2 rounded border-gray-300 text-gray-300 disabled:cursor-not-allowed text-base h-28 w-56"
+          className="p-4 border-2 rounded text-slate-600 border-slate-200 hover:border-slate-300 focus:border-slate-300 text-base h-28 w-56"
+          onClick={() => {
+            setAssetFilter(false);
+            setCurrentStep('select-destination');
+          }}
         >
           Let me choose which videos
-          <br />
-          <span className="text-xs italic">Coming soon</span>
         </button>
       </div>
     </div>

--- a/app/components/shared/import-settings.tsx
+++ b/app/components/shared/import-settings.tsx
@@ -42,7 +42,7 @@ const PLATFORM_METADATA_FIELDS: { id: string; fields: Field[] }[] = [
         docsUrl: 'https://docs.mux.com/guides/stream-videos-in-4k',
         name: 'maxResolutionTier',
         type: 'select',
-        values: (config) => (config.videoQuality === 'basic' ? ['1080p'] : ['1080p', '1440p', '2160p']),
+        values: ['1080p', '1440p', '2160p'],
       },
       {
         label: 'Auto-generate captions',

--- a/app/components/shared/migration-status.tsx
+++ b/app/components/shared/migration-status.tsx
@@ -119,21 +119,23 @@ export default function MigrationStatus() {
         throw new Error(errorBody.error || 'Failed to enqueue upload start');
       }
 
+      setSelectedIds((prev) => prev.filter((id) => !ids.includes(id)));
+      toast.success(`Started ${videos.length} upload${videos.length > 1 ? 's' : ''}`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to start uploads';
+
       for (const video of videos) {
         const current = useMigrationStore.getState().job?.videos[video.id];
         if (!current) continue;
         setVideoMigrationProgress(video.id, {
           ...current,
-          status: 'in-progress',
-          progress: current.progress || 0,
-          error: '',
+          status: 'failed',
+          progress: 100,
+          error: errorMessage,
         });
       }
 
-      setSelectedIds((prev) => prev.filter((id) => !ids.includes(id)));
-      toast.success(`Started ${videos.length} upload${videos.length > 1 ? 's' : ''}`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to start uploads');
+      toast.error(errorMessage);
     } finally {
       setStartingIds((prev) => {
         const next = { ...prev };

--- a/app/components/shared/migration-status.tsx
+++ b/app/components/shared/migration-status.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+
 import clsx from 'clsx';
 import usePartySocket from 'partysocket/react';
 
@@ -9,9 +12,136 @@ import Heading from '../heading';
 
 // import type { VideoWithMigrationStatus } from '@/utils/store';
 
+type VideoStatusFilter = 'all' | 'pending' | 'in-progress' | 'retrying' | 'completed' | 'failed';
+
+function formatDuration(durationSeconds?: number): string | null {
+  if (typeof durationSeconds !== 'number' || !Number.isFinite(durationSeconds) || durationSeconds < 0) {
+    return null;
+  }
+
+  const totalSeconds = Math.floor(durationSeconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const minutePart = String(minutes).padStart(2, '0');
+  const secondPart = String(seconds).padStart(2, '0');
+  if (hours > 0) {
+    return `${hours}:${minutePart}:${secondPart}`;
+  }
+
+  return `${minutePart}:${secondPart}`;
+}
+
 export default function MigrationStatus() {
   const job = useMigrationStore((state) => state.job);
+  const sourcePlatform = useMigrationStore((state) => state.sourcePlatform);
+  const destinationPlatform = useMigrationStore((state) => state.destinationPlatform);
+  const assetFilter = useMigrationStore((state) => state.assetFilter);
   const setVideoMigrationProgress = useMigrationStore((state) => state.setVideoMigrationProgress);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [startingIds, setStartingIds] = useState<Record<string, boolean>>({});
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [filterText, setFilterText] = useState('');
+  const [statusFilter, setStatusFilter] = useState<VideoStatusFilter>('all');
+
+  const getSourceLink = (id: string): string | null => {
+    if (!sourcePlatform) return null;
+
+    if (sourcePlatform.id === 'vimeo') {
+      const normalizedId = id.replace(/^\/videos\//, '');
+      return `https://vimeo.com/manage/videos/${normalizedId}`;
+    }
+
+    return null;
+  };
+
+  const videoIds = Object.keys(job?.videos || {});
+  const filteredVideoIds = useMemo(() => {
+    const query = filterText.trim().toLowerCase();
+    return videoIds.filter((id) => {
+      const video = job?.videos[id];
+      if (!video) return false;
+
+      const matchesStatus = statusFilter === 'all' || video.status === statusFilter;
+      if (!matchesStatus) return false;
+
+      if (!query) return true;
+
+      const title = (video.title || '').toLowerCase();
+      const normalizedId = video.id.toLowerCase();
+      return title.includes(query) || normalizedId.includes(query);
+    });
+  }, [filterText, job?.videos, statusFilter, videoIds]);
+
+  const pendingVideoIds = useMemo(
+    () => videoIds.filter((id) => job?.videos[id]?.status === 'pending'),
+    [videoIds, job?.videos]
+  );
+  const filteredPendingVideoIds = useMemo(
+    () => filteredVideoIds.filter((id) => job?.videos[id]?.status === 'pending'),
+    [filteredVideoIds, job?.videos]
+  );
+  const selectedPendingIds = selectedIds.filter((id) => pendingVideoIds.includes(id));
+  const selectedFilteredPendingIds = selectedIds.filter((id) => filteredPendingVideoIds.includes(id));
+  const isManualSelectionMode = assetFilter === false;
+
+  const startUploads = async (ids: string[]) => {
+    if (!job || !sourcePlatform || !destinationPlatform || ids.length === 0) return;
+
+    const videos = ids
+      .map((id) => job.videos[id])
+      .filter((video): video is NonNullable<typeof video> => !!video)
+      .map((video) => ({ id: video.id, title: video.title }));
+
+    if (!videos.length) return;
+
+    const updates = videos.reduce<Record<string, boolean>>((acc, video) => {
+      acc[video.id] = true;
+      return acc;
+    }, {});
+    setStartingIds((prev) => ({ ...prev, ...updates }));
+
+    try {
+      const response = await fetch('/api/job', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jobId: job.id,
+          sourcePlatform,
+          destinationPlatform,
+          videos,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to enqueue upload start');
+      }
+
+      for (const video of videos) {
+        const current = useMigrationStore.getState().job?.videos[video.id];
+        if (!current) continue;
+        setVideoMigrationProgress(video.id, {
+          ...current,
+          status: 'in-progress',
+          progress: current.progress || 0,
+          error: '',
+        });
+      }
+
+      setSelectedIds((prev) => prev.filter((id) => !ids.includes(id)));
+      toast.success(`Started ${videos.length} upload${videos.length > 1 ? 's' : ''}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to start uploads');
+    } finally {
+      setStartingIds((prev) => {
+        const next = { ...prev };
+        for (const id of ids) delete next[id];
+        return next;
+      });
+    }
+  };
 
   const socket = usePartySocket({
     host: process.env.NEXT_PUBLIC_PARTYKIT_URL,
@@ -25,13 +155,22 @@ export default function MigrationStatus() {
 
       switch (payload.type) {
         case 'migration.videos.fetched':
-          const { hasMorePages, pageNumber, videos } = payload.data;
           useMigrationStore.setState({ job: { ...job, ...payload.data } });
           break;
         case 'migration.video.progress':
           const { video } = payload.data;
 
           setVideoMigrationProgress(video.id, video);
+          break;
+        case 'migration.job.halted':
+          useMigrationStore.setState({
+            job: {
+              ...useMigrationStore.getState().job!,
+              halted: true,
+              haltReason: payload.data?.reason,
+              status: 'failed',
+            },
+          });
           break;
         default:
           break;
@@ -43,43 +182,207 @@ export default function MigrationStatus() {
     useMigrationStore.setState({ job: undefined, currentStep: 'review' });
   };
 
-  const videoIds = Object.keys(job?.videos || {});
+  const refreshVideoList = async () => {
+    if (!job?.id || !sourcePlatform) return;
+
+    setIsRefreshing(true);
+    try {
+      const response = await fetch('/api/job', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'refresh-videos',
+          jobId: job.id,
+          sourcePlatform,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to refresh video list');
+      }
+
+      toast.success('Refreshing video list...');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to refresh video list');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
 
   return (
     <div>
       <Heading>Migration Status</Heading>
       {/* {job?.status} */}
       <p className="text-xs mb-2">Note: this page updates in real-time as videos are processed.</p>
+      {isManualSelectionMode && (
+        <div className="mb-3 flex items-center gap-3">
+          <button
+            className="text-sm rounded border border-slate-300 px-3 py-1 disabled:opacity-50"
+            onClick={refreshVideoList}
+            disabled={!job?.id || !sourcePlatform || isRefreshing}
+          >
+            {isRefreshing ? 'Refreshing...' : 'Refresh video list'}
+          </button>
+          <div className="grow" />
+          <span className="text-xs text-slate-500">
+            {selectedPendingIds.length}/{pendingVideoIds.length} selected
+          </span>
+          <button
+            className="text-sm rounded border border-slate-300 px-3 py-1 disabled:opacity-50"
+            disabled={selectedPendingIds.length === 0}
+            onClick={() => startUploads(selectedPendingIds)}
+          >
+            Upload selected
+          </button>
+        </div>
+      )}
+
+      <div className="mb-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_220px]">
+        <div>
+          <label htmlFor="migration-status-filter" className="mb-1 block text-xs text-slate-600">
+            Filter by video name or ID
+          </label>
+          <input
+            id="migration-status-filter"
+            type="text"
+            value={filterText}
+            onChange={(event) => setFilterText(event.target.value)}
+            placeholder="Search videos..."
+            className="w-full rounded border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+        </div>
+        <div>
+          <label htmlFor="migration-status-filter-status" className="mb-1 block text-xs text-slate-600">
+            Filter by status
+          </label>
+          <select
+            id="migration-status-filter-status"
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as VideoStatusFilter)}
+            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            <option value="all">All statuses</option>
+            <option value="pending">Pending</option>
+            <option value="in-progress">In progress</option>
+            <option value="retrying">Retrying</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+          </select>
+        </div>
+      </div>
 
       <div className="relative w-full overflow-auto">
-        <table className="w-full caption-bottom text-sm">
+        <table className="w-full table-auto caption-bottom text-sm">
           <thead className="[&amp;_tr]:border-b">
             <tr className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted">
-              <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0 w-[180px]">
+              {isManualSelectionMode && (
+                <th className="h-12 w-px whitespace-nowrap px-4 text-left align-middle font-medium text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={
+                      filteredPendingVideoIds.length > 0 &&
+                      selectedFilteredPendingIds.length === filteredPendingVideoIds.length
+                    }
+                    onChange={(event) => {
+                      if (event.target.checked) {
+                        setSelectedIds((prev) => [...new Set([...prev, ...filteredPendingVideoIds])]);
+                      } else {
+                        setSelectedIds((prev) => prev.filter((id) => !filteredPendingVideoIds.includes(id)));
+                      }
+                    }}
+                    aria-label="Select pending videos"
+                  />
+                </th>
+              )}
+              <th className="h-12 w-full px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
                 Video
               </th>
-              <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
+              <th className="h-12 w-px whitespace-nowrap px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
                 Progress
               </th>
-              <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
+              <th className="h-12 w-px whitespace-nowrap px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
                 Status
+              </th>
+              <th className="h-12 w-px whitespace-nowrap px-4 text-left align-middle font-medium text-muted-foreground [&amp;:has([role=checkbox])]:pr-0">
+                Action
               </th>
             </tr>
           </thead>
           <tbody className="[&amp;_tr:last-child]:border-0">
-            {videoIds.map((id) => {
+            {filteredVideoIds.map((id) => {
               const video = job?.videos[id];
               if (!video) return null;
+              const durationLabel = formatDuration(video.durationSeconds);
+              const sourceLink = getSourceLink(video.id);
               return (
                 <tr
                   key={video.id}
-                  className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
+                  className="h-[108px] border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
                 >
-                  <td className="p-4 align-middle [&amp;:has([role=checkbox])]:pr-0 font-medium">
-                    {video.title || video.id}
+                  {isManualSelectionMode && (
+                    <td className="p-4 align-middle">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.includes(video.id)}
+                        disabled={video.status !== 'pending'}
+                        onChange={(event) => {
+                          setSelectedIds((prev) => {
+                            if (event.target.checked) {
+                              return [...new Set([...prev, video.id])];
+                            }
+                            return prev.filter((id) => id !== video.id);
+                          });
+                        }}
+                        aria-label={`Select ${video.title || video.id}`}
+                      />
+                    </td>
+                  )}
+                  <td className="w-full p-4 align-middle font-medium [&amp;:has([role=checkbox])]:pr-0">
+                    <div className="flex min-h-[84px] items-center gap-3">
+                      <div className="relative h-[84px] w-[150px] shrink-0 overflow-hidden rounded border border-slate-200 bg-slate-100">
+                        {video.thumbnailUrl ? (
+                          <img
+                            src={video.thumbnailUrl}
+                            alt={video.title || video.id}
+                            width={150}
+                            className="block h-full w-[150px] object-cover"
+                            loading="lazy"
+                            referrerPolicy="no-referrer"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                            No preview
+                          </div>
+                        )}
+                        {durationLabel ? (
+                          <span className="absolute bottom-1 right-1 rounded bg-black/75 px-1.5 py-0.5 text-[11px] font-medium text-white">
+                            {durationLabel}
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <div className="flex h-[84px] min-w-0 flex-col justify-center">
+                        <p className="truncate">{video.title || video.id}</p>
+                        {sourceLink ? (
+                          <a
+                            href={sourceLink}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="mt-1 truncate text-xs font-normal text-primary underline"
+                          >
+                            {video.id}
+                          </a>
+                        ) : (
+                          <p className="mt-1 truncate text-xs font-normal text-slate-500">{video.id}</p>
+                        )}
+                      </div>
+                    </div>
                   </td>
-                  <td className="p-4 align-middle [&amp;:has([role=checkbox])]:pr-0">{video.progress}%</td>
-                  <td className="p-4 align-middle [&amp;:has([role=checkbox])]:pr-0">
+                  <td className="w-px whitespace-nowrap p-4 align-middle [&amp;:has([role=checkbox])]:pr-0">
+                    {video.progress}%
+                  </td>
+                  <td className="w-px whitespace-nowrap p-4 align-middle [&amp;:has([role=checkbox])]:pr-0">
                     <span
                       className={clsx(
                         'rounded-full px-3 py-1 capitalize text-xs',
@@ -91,10 +394,47 @@ export default function MigrationStatus() {
                     >
                       {video.status}
                     </span>
+                    {video.error ? (
+                      <span
+                        className="ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full border border-red-300 text-[10px] font-semibold text-red-700 cursor-help"
+                        title={video.error}
+                        aria-label={video.error}
+                      >
+                        ?
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="w-px whitespace-nowrap p-4 align-middle [&amp;:has([role=checkbox])]:pr-0">
+                    {video.status === 'failed' ? (
+                      <button
+                        className="text-xs rounded border border-primary px-2 py-1 text-primary disabled:opacity-50"
+                        disabled={!!startingIds[video.id]}
+                        onClick={() => startUploads([video.id])}
+                      >
+                        {startingIds[video.id] ? 'Retrying...' : 'Retry'}
+                      </button>
+                    ) : isManualSelectionMode && video.status === 'pending' ? (
+                      <button
+                        className="text-xs rounded border border-primary px-2 py-1 text-primary disabled:opacity-50"
+                        disabled={!!startingIds[video.id]}
+                        onClick={() => startUploads([video.id])}
+                      >
+                        {startingIds[video.id] ? 'Starting...' : 'Start upload'}
+                      </button>
+                    ) : (
+                      <span className="text-slate-400 text-xs">-</span>
+                    )}
                   </td>
                 </tr>
               );
             })}
+            {filteredVideoIds.length === 0 ? (
+              <tr>
+                <td className="p-4 text-sm text-slate-500" colSpan={isManualSelectionMode ? 5 : 4}>
+                  No videos match the current filters.
+                </td>
+              </tr>
+            ) : null}
           </tbody>
         </table>
       </div>

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -13,6 +13,8 @@ export default function Sidebar() {
   const assetFilter = useMigrationStore((state) => state.assetFilter);
   const setAssetFilter = useMigrationStore((state) => state.setAssetFilter);
 
+  const isManualSelection = assetFilter === false;
+
   const state = useMigrationStore.getState();
 
   console.dir(state);
@@ -92,7 +94,7 @@ export default function Sidebar() {
           <div className="flex justify-between border-b border-slate-200 pb-2">
             <div className="flex flex-col">
               <h3 className="font-semibold text-sm">Video selection</h3>
-              <p className="text-sm">Moving all videos</p>
+              <p className="text-sm">{isManualSelection ? 'Choose videos in status page' : 'Moving all videos'}</p>
             </div>
 
             <button

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
       useMigrationStore.setState({ currentStep: 'select-source' });
     } else if (!sourcePlatform?.credentials) {
       useMigrationStore.setState({ currentStep: 'set-source-credentials' });
-    } else if (sourcePlatform?.credentials && !useMigrationStore.getState().assetFilter) {
+    } else if (sourcePlatform?.credentials && useMigrationStore.getState().assetFilter === null) {
       useMigrationStore.setState({ currentStep: 'set-video-filter' });
     } else if (!destinationPlatform) {
       useMigrationStore.setState({ currentStep: 'select-destination' });

--- a/app/party/index.ts
+++ b/app/party/index.ts
@@ -7,15 +7,77 @@ export default class Server implements Party.Server {
 
   job: MigrationJob | undefined;
 
+  private recomputeJobStatus() {
+    if (!this.job) return;
+
+    const statuses = Object.values(this.job.videos || {}).map((video) => video.status);
+    if (statuses.length === 0) {
+      this.job.status = 'pending';
+      return;
+    }
+
+    if (statuses.some((status) => status === 'in-progress' || status === 'retrying')) {
+      this.job.status = 'in-progress';
+      return;
+    }
+
+    if (statuses.every((status) => status === 'completed')) {
+      this.job.status = 'completed';
+      return;
+    }
+
+    if (statuses.every((status) => status === 'completed' || status === 'failed')) {
+      this.job.status = statuses.some((status) => status === 'failed') ? 'failed' : 'completed';
+      return;
+    }
+
+    this.job.status = 'pending';
+  }
+
   async onRequest(req: Party.Request) {
     if (req.method === 'POST') {
-      const job = (await req.json()) as MigrationJob;
-      this.job = { ...job, status: 'pending' };
+      const job = (await req.json()) as Partial<MigrationJob>;
+      this.job = {
+        id: job.id || this.room.id,
+        status: 'pending',
+        progress: 0,
+        videos: job.videos || {},
+        halted: false,
+      };
+      return new Response('OK');
     }
 
     if (req.method === 'PUT') {
       const payload = await req.json<{ id: string; type: string; data: any }>();
-      // this.job.messages.push(payload.message);
+      if (!this.job) {
+        this.job = { id: payload.id || this.room.id, status: 'pending', progress: 0, videos: {}, halted: false };
+      }
+
+      if (payload.type === 'migration.videos.fetched') {
+        const incomingVideos = payload.data.videos || {};
+
+        // Keep existing statuses/progress for known videos and add newly discovered videos as pending.
+        this.job.videos = {
+          ...incomingVideos,
+          ...this.job.videos,
+        };
+        this.recomputeJobStatus();
+      }
+
+      if (payload.type === 'migration.video.progress') {
+        const video = payload.data?.video;
+        if (video?.id) {
+          this.job.videos[video.id] = { ...this.job.videos[video.id], ...video };
+          this.recomputeJobStatus();
+        }
+      }
+
+      if (payload.type === 'migration.job.halted') {
+        this.job.halted = true;
+        this.job.haltReason = payload.data?.reason || 'Migration halted due to an upstream error.';
+        this.job.status = 'failed';
+      }
+
       this.room.broadcast(JSON.stringify(payload));
       return new Response('OK');
     }

--- a/app/utils/job.tsx
+++ b/app/utils/job.tsx
@@ -1,19 +1,31 @@
 export async function createJob(jobId: string): Promise<Response> {
-  return fetch(`${process.env.NEXT_PUBLIC_PARTYKIT_URL}/party/${jobId}`, {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_PARTYKIT_URL}/party/${jobId}`, {
     method: 'POST',
     body: JSON.stringify({ id: jobId }),
     headers: {
       'Content-Type': 'application/json',
     },
   });
+
+  if (!response.ok) {
+    throw new Error(`Failed to create job in PartyKit: ${response.status}`);
+  }
+
+  return response;
 }
 
 export async function updateJobStatus(jobId: string, eventType: string, data: any): Promise<Response> {
-  return fetch(`${process.env.NEXT_PUBLIC_PARTYKIT_URL}/party/${jobId}`, {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_PARTYKIT_URL}/party/${jobId}`, {
     method: 'PUT',
     body: JSON.stringify({ id: jobId, type: eventType, data }),
     headers: {
       'Content-Type': 'application/json',
     },
   });
+
+  if (!response.ok) {
+    throw new Error(`Failed to update job in PartyKit: ${response.status}`);
+  }
+
+  return response;
 }

--- a/app/utils/store.tsx
+++ b/app/utils/store.tsx
@@ -142,7 +142,8 @@ const useMigrationStore = create<MigrationState & MigrationActions>()(
         setVideoMigrationProgress: (id: string, status: VideoWithMigrationStatus) => {
           set((state) => {
             if (state.job) {
-              state.job.videos[id] = status;
+              const existing = state.job.videos[id];
+              state.job.videos[id] = existing ? { ...existing, ...status } : status;
             }
           });
         },

--- a/app/utils/store.tsx
+++ b/app/utils/store.tsx
@@ -28,6 +28,7 @@ export type MigrationVideosFetchedEvent = {
 export type MigrationStatus = {
   status: 'pending' | 'in-progress' | 'retrying' | 'completed' | 'failed';
   progress: number;
+  error?: string;
 };
 
 export type Video = {
@@ -35,6 +36,7 @@ export type Video = {
   url?: string | undefined;
   title?: string | undefined;
   thumbnailUrl?: string | undefined;
+  durationSeconds?: number | undefined;
 };
 
 export type VideoWithMigrationStatus = Video & MigrationStatus;
@@ -71,19 +73,19 @@ interface Platform {
   config?: PlatformConfig | undefined;
 }
 
-export type AssetFilter = {
-  url: string;
-};
+export type AssetFilter = boolean;
 
 export type MigrationJob = {
   id: string;
   status: 'pending' | 'in-progress' | 'completed' | 'failed';
   progress: number;
   videos: Record<string, VideoWithMigrationStatus>;
+  halted?: boolean;
+  haltReason?: string;
 };
 
 type MigrationActions = {
-  setAssetFilter: (filter: AssetFilter[] | null) => void;
+  setAssetFilter: (filter: AssetFilter | null) => void;
   setPlatform: <T extends PlatformType>(
     type: T,
     platform: T extends 'source' ? SourcePlatform | null : DestinationPlatform | null
@@ -95,7 +97,7 @@ type MigrationActions = {
 interface MigrationState {
   sourcePlatform: SourcePlatform | null;
   destinationPlatform: DestinationPlatform | null;
-  assetFilter: AssetFilter[] | null;
+  assetFilter: AssetFilter | null;
   job: MigrationJob | null;
   currentStep: MigrationStep;
 }
@@ -124,7 +126,7 @@ const useMigrationStore = create<MigrationState & MigrationActions>()(
         setCurrentStep: (step: MigrationStep) => {
           set({ currentStep: step });
         },
-        setAssetFilter: (filter: AssetFilter[] | null) => {
+        setAssetFilter: (filter: AssetFilter | null) => {
           set({ assetFilter: filter });
         },
         setPlatform: <T extends PlatformType>(

--- a/app/workflows/__tests__/providers.test.ts
+++ b/app/workflows/__tests__/providers.test.ts
@@ -153,8 +153,22 @@ describe('Vimeo provider', () => {
           page: 1,
           per_page: 25,
           data: [
-            { uri: '/videos/1', name: 'V1', status: 'available', type: 'video' },
-            { uri: '/videos/2', name: 'V2', status: 'available', type: 'video' },
+            {
+              uri: '/videos/1',
+              name: 'V1',
+              status: 'available',
+              type: 'video',
+              duration: 65,
+              pictures: { sizes: [{ link: 'https://i.vimeocdn.com/video/1_100x75.jpg' }] },
+            },
+            {
+              uri: '/videos/2',
+              name: 'V2',
+              status: 'available',
+              type: 'video',
+              duration: 3700,
+              pictures: { base_link: 'https://i.vimeocdn.com/video/2_base.jpg' },
+            },
           ],
         }),
     });
@@ -162,6 +176,16 @@ describe('Vimeo provider', () => {
     const result = await fetchPageVimeo({ publicKey: '', secretKey: 'token' }, 1);
 
     expect(result.videos).toHaveLength(2);
+    expect(result.videos[0]).toMatchObject({
+      id: '/videos/1',
+      thumbnailUrl: 'https://i.vimeocdn.com/video/1_100x75.jpg',
+      durationSeconds: 65,
+    });
+    expect(result.videos[1]).toMatchObject({
+      id: '/videos/2',
+      thumbnailUrl: 'https://i.vimeocdn.com/video/2_base.jpg',
+      durationSeconds: 3700,
+    });
     expect(result.isTruncated).toBe(false);
   });
 
@@ -173,6 +197,13 @@ describe('Vimeo provider', () => {
           name: 'My Video',
           status: 'available',
           type: 'video',
+          duration: 3723,
+          pictures: {
+            sizes: [
+              { width: 100, link: 'https://i.vimeocdn.com/video/small.jpg' },
+              { width: 1280, link: 'https://i.vimeocdn.com/video/large.jpg' },
+            ],
+          },
           download: [{ rendition: 'source', link: 'https://vimeo.com/download/1.mp4' }],
         }),
     });
@@ -183,6 +214,8 @@ describe('Vimeo provider', () => {
       id: '/videos/1',
       url: 'https://vimeo.com/download/1.mp4',
       title: 'My Video',
+      thumbnailUrl: 'https://i.vimeocdn.com/video/large.jpg',
+      durationSeconds: 3723,
     });
   });
 });

--- a/app/workflows/migration.ts
+++ b/app/workflows/migration.ts
@@ -7,10 +7,47 @@ import {
   checkMuxAssetStatusStep,
   fetchPageStep,
   fetchVideoStep,
+  getJobHaltStatusStep,
   startProcessVideoWorkflow,
   transferVideoStep,
   updateJobStatusStep,
 } from './steps';
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  if (typeof error === 'object' && error !== null) {
+    const maybeMessage = (error as { message?: unknown }).message;
+    if (typeof maybeMessage === 'string' && maybeMessage.trim().length > 0) {
+      return maybeMessage;
+    }
+
+    const maybeError = (error as { error?: unknown }).error;
+    if (typeof maybeError === 'string' && maybeError.trim().length > 0) {
+      return maybeError;
+    }
+
+    if (typeof maybeError === 'object' && maybeError !== null) {
+      const nestedMessage = (maybeError as { message?: unknown }).message;
+      if (typeof nestedMessage === 'string' && nestedMessage.trim().length > 0) {
+        return nestedMessage;
+      }
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+
+  return 'Unknown workflow error';
+}
+
+function isMuxFreePlanLimitError(errorMessage: string): boolean {
+  return errorMessage.includes('Free plan is limited to 10 assets');
+}
 
 export async function processVideo(
   jobId: string,
@@ -20,56 +57,88 @@ export async function processVideo(
 ) {
   'use workflow';
 
-  let video = await fetchVideoStep(sourcePlatform.id, sourcePlatform.credentials!, videoData);
-
-  if (!video) {
-    throw new FatalError(`Failed to fetch video with ID: ${videoData.id}`);
+  const haltStatus = await getJobHaltStatusStep(jobId);
+  if (haltStatus.halted) {
+    const haltMessage = haltStatus.reason || 'Migration was halted due to a previous failure.';
+    await updateJobStatusStep(jobId, 'migration.video.progress', {
+      video: {
+        id: videoData.id,
+        status: 'failed',
+        progress: 100,
+        error: haltMessage,
+      },
+    });
+    return { status: 'failed', skipped: true, reason: haltMessage };
   }
 
-  // Handle Cloudflare Stream polling case
-  if (video.needsPolling) {
-    let status = { ready: false, url: '' };
-    while (!status.ready) {
-      await sleep('5s');
-      status = await checkCloudflareStatusStep(sourcePlatform.credentials!, videoData);
+  try {
+    let video = await fetchVideoStep(sourcePlatform.id, sourcePlatform.credentials!, videoData);
+
+    // Handle Cloudflare Stream polling case
+    if (video.needsPolling) {
+      let status = { ready: false, url: '' };
+      while (!status.ready) {
+        await sleep('5s');
+        status = await checkCloudflareStatusStep(sourcePlatform.credentials!, videoData);
+      }
+      video = { id: videoData.id, url: status.url };
     }
-    video = { id: videoData.id, url: status.url };
+
+    const transfer = await transferVideoStep(jobId, video, sourcePlatform, destinationPlatform);
+    const assetId = transfer.result.id;
+
+    // Poll Mux until asset is ready (replaces webhook/ngrok approach)
+    let assetStatus = { ready: false, errored: false };
+    while (!assetStatus.ready && !assetStatus.errored) {
+      await sleep('5s');
+      assetStatus = await checkMuxAssetStatusStep(destinationPlatform.credentials!, assetId);
+    }
+
+    await updateJobStatusStep(jobId, 'migration.video.progress', {
+      video: {
+        id: videoData.id,
+        status: assetStatus.ready ? 'completed' : 'failed',
+        progress: 100,
+        ...(assetStatus.errored ? { error: 'Mux asset processing failed.' } : {}),
+      },
+    });
+
+    return { status: assetStatus.ready ? 'success' : 'failed', transfer };
+  } catch (error) {
+    const errorMessage = getErrorMessage(error);
+
+    await updateJobStatusStep(jobId, 'migration.video.progress', {
+      video: {
+        id: videoData.id,
+        status: 'failed',
+        progress: 100,
+        error: errorMessage,
+      },
+    });
+
+    if (isMuxFreePlanLimitError(errorMessage)) {
+      await updateJobStatusStep(jobId, 'migration.job.halted', {
+        reason: errorMessage,
+      });
+    }
+
+    throw new FatalError(errorMessage);
   }
-
-  const transfer = await transferVideoStep(jobId, video, sourcePlatform, destinationPlatform);
-  const assetId = transfer.result.id;
-
-  // Poll Mux until asset is ready (replaces webhook/ngrok approach)
-  let assetStatus = { ready: false, errored: false };
-  while (!assetStatus.ready && !assetStatus.errored) {
-    await sleep('5s');
-    assetStatus = await checkMuxAssetStatusStep(destinationPlatform.credentials!, assetId);
-  }
-
-  await updateJobStatusStep(jobId, 'migration.video.progress', {
-    video: {
-      id: videoData.id,
-      status: assetStatus.ready ? 'completed' : 'failed',
-      progress: 100,
-    },
-  });
-
-  return { status: assetStatus.ready ? 'success' : 'failed', transfer };
 }
 
 export async function initiateMigration(data: {
   sourcePlatform: SourcePlatform;
   destinationPlatform: DestinationPlatform;
-  assetFilter: any;
+  assetFilter: boolean | null;
 }) {
   'use workflow';
 
   const { workflowRunId: jobId } = getWorkflowMetadata();
-
   let hasMorePages = true;
   let page = 1;
   let cursor: string | undefined;
   let videoList: Video[] = [];
+  const useManualSelection = data.assetFilter === false;
 
   while (hasMorePages && data.sourcePlatform.credentials) {
     const result = await fetchPageStep(data.sourcePlatform.id, data.sourcePlatform.credentials, page, cursor);
@@ -94,10 +163,47 @@ export async function initiateMigration(data: {
     }
   }
 
-  // Start a processVideo workflow for each video
-  for (const video of videoList) {
-    await startProcessVideoWorkflow(jobId, data.sourcePlatform, data.destinationPlatform, video);
+  if (!useManualSelection) {
+    for (const video of videoList) {
+      await startProcessVideoWorkflow(jobId, data.sourcePlatform, data.destinationPlatform, video);
+    }
+
+    return { message: 'migration started', videosStarted: videoList.length };
   }
 
-  return { message: 'migration initiated', videosMigrated: videoList.length };
+  return { message: 'migration queued', videosQueued: videoList.length };
+}
+
+export async function refreshVideoList(jobId: string, sourcePlatform: SourcePlatform) {
+  'use workflow';
+
+  let hasMorePages = true;
+  let page = 1;
+  let cursor: string | undefined;
+  let videoList: Video[] = [];
+
+  while (hasMorePages && sourcePlatform.credentials) {
+    const result = await fetchPageStep(sourcePlatform.id, sourcePlatform.credentials, page, cursor);
+    const { isTruncated, videos } = result;
+    cursor = result.cursor ?? undefined;
+
+    videoList = videoList.concat(videos);
+
+    await updateJobStatusStep(jobId, 'migration.videos.fetched', {
+      pageNumber: page,
+      videos: videoList.reduce<Record<string, VideoWithMigrationStatus>>((acc, video) => {
+        acc[video.id] = { ...video, status: 'pending', progress: 0 };
+        return acc;
+      }, {}),
+      hasMorePages: isTruncated,
+    });
+
+    if (!isTruncated) {
+      hasMorePages = false;
+    } else {
+      page++;
+    }
+  }
+
+  return { message: 'video list refreshed', videosFetched: videoList.length };
 }

--- a/app/workflows/steps.ts
+++ b/app/workflows/steps.ts
@@ -17,6 +17,24 @@ function getApiVideoEndpoint(credentials: PlatformCredentials) {
 
 type FetchPageResult = { isTruncated: boolean | undefined; videos: Video[]; cursor: string | null | undefined };
 
+function getVimeoThumbnailUrl(video: any): string | undefined {
+  if (Array.isArray(video?.pictures?.sizes) && video.pictures.sizes.length > 0) {
+    const largest = video.pictures.sizes[video.pictures.sizes.length - 1];
+    if (typeof largest?.link === 'string' && largest.link.trim().length > 0) return largest.link;
+  }
+
+  if (typeof video?.pictures?.base_link === 'string' && video.pictures.base_link.trim().length > 0) {
+    return video.pictures.base_link;
+  }
+
+  return undefined;
+}
+
+function getVimeoDurationSeconds(video: any): number | undefined {
+  if (typeof video?.duration !== 'number' || !Number.isFinite(video.duration) || video.duration < 0) return undefined;
+  return Math.floor(video.duration);
+}
+
 // --- Fetch Page implementations ---
 
 export async function fetchPageApiVideo(credentials: PlatformCredentials, page: number): Promise<FetchPageResult> {
@@ -68,8 +86,15 @@ export async function fetchPageVimeo(credentials: PlatformCredentials, page: num
   const isTruncated = result.page < Math.ceil(result.total / result.per_page);
   const videos =
     result.data
-      ?.map((obj: any) => ({ id: obj.uri, title: obj.name, status: obj.status, type: obj.type }))
-      .filter((item: any): item is Video => !!item.id && !(item.status !== 'available' && item.type !== 'video')) || [];
+      ?.map((obj: any) => ({
+        id: obj.uri,
+        title: obj.name,
+        thumbnailUrl: getVimeoThumbnailUrl(obj),
+        durationSeconds: getVimeoDurationSeconds(obj),
+        status: obj.status,
+        type: obj.type,
+      }))
+      .filter((item: any): item is Video => !!item.id && item.status === 'available' && item.type === 'video') || [];
   return { isTruncated, videos, cursor: null };
 }
 
@@ -165,14 +190,29 @@ export async function fetchVideoVimeo(credentials: PlatformCredentials, video: V
       'Content-Type': 'application/json',
     },
   });
+  if (typeof response.ok === 'boolean' && !response.ok) {
+    throw new Error(`Vimeo API request failed for ${video.id} with status ${response.status}`);
+  }
+
   const result = await response.json();
   if (!result) throw new Error('Error fetching video from Vimeo');
   if (result.download && result.status === 'available' && result.type === 'video') {
     const renditions = ['source', '8k', '7k', '6k', '5k', '4k', '2k', '1080p', '720p', '540p', '480p', '360p', '240p'];
     const download = result.download.find((f: any) => renditions.includes(f.rendition));
-    return { id: video.id, url: download?.link, title: result?.name };
+    if (!download?.link) {
+      throw new Error(`Vimeo video ${video.id} has no supported downloadable rendition`);
+    }
+    return {
+      id: video.id,
+      url: download?.link,
+      title: result?.name,
+      thumbnailUrl: getVimeoThumbnailUrl(result),
+      durationSeconds: getVimeoDurationSeconds(result),
+    };
   }
-  return undefined;
+  throw new Error(
+    `Vimeo video ${video.id} is not available for download (status=${result.status}, type=${result.type})`
+  );
 }
 
 export async function fetchVideoWistia(_credentials: PlatformCredentials, video: Video) {
@@ -351,6 +391,22 @@ export async function updateJobStatusStep(jobId: string, eventType: string, data
     body: JSON.stringify({ id: jobId, type: eventType, data }),
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+export async function getJobHaltStatusStep(jobId: string): Promise<{ halted: boolean; reason?: string }> {
+  'use step';
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_PARTYKIT_URL}/party/${jobId}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    return { halted: false };
+  }
+
+  const job = (await response.json()) as { halted?: boolean; haltReason?: string };
+  return { halted: !!job.halted, reason: job.haltReason };
 }
 
 export async function startProcessVideoWorkflow(

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "autoprefixer": "^10.4.17",
         "concurrently": "^8.2.2",
         "nock": "^14.0.15",
-        "partykit": "0.0.93",
+        "partykit": "^0.0.115",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.21.0",
@@ -515,6 +515,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
       "integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.515.0",
         "@aws-sdk/credential-provider-http": "3.515.0",
@@ -2015,7 +2016,6 @@
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
       "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
@@ -2099,10 +2099,27 @@
         "win32"
       ]
     },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240718.0.tgz",
+      "integrity": "sha512-BsPZcSCgoGnufog2GIgdPuiKicYTNyO/Dp++HbpLRH+yQdX3x4aWx83M+a0suTl1xv76dO4g9aw7SIB6OSgIyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240208.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240208.0.tgz",
-      "integrity": "sha512-eVQrAV200LhwLY6JZLx3l2lDrjsTC86lqnvH+RSeM43bAcdneC6lVfykHnTaOTgYFvYQbqRkn9ICWxXj1V9L5g==",
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240718.0.tgz",
+      "integrity": "sha512-nlr4gaOO5gcJerILJQph3+2rnas/nx/lYsuaot1ntHu4LAPBoQo1q/Pucj2cSIav4UiMzTbDmoDwPlls4Kteog==",
       "cpu": [
         "arm64"
       ],
@@ -2116,10 +2133,61 @@
         "node": ">=16"
       }
     },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240718.0.tgz",
+      "integrity": "sha512-LJ/k3y47pBcjax0ee4K+6ZRrSsqWlfU4lbU8Dn6u5tSC9yzwI4YFNXDrKWInB0vd7RT3w4Yqq1S6ZEbfRrqVUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240718.0.tgz",
+      "integrity": "sha512-zBEZvy88EcAMGRGfuVtS00Yl7lJdUM9sH7i651OoL+q0Plv9kphlCC0REQPwzxrEYT1qibSYtWcD9IxQGgx2/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240718.0.tgz",
+      "integrity": "sha512-YpCRvvT47XanFum7C3SedOZKK6BfVhqmwdAAVAQFyc4gsCdegZo0JkUkdloC/jwuWlbCACOG2HTADHOqyeolzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20240222.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240222.0.tgz",
-      "integrity": "sha512-luO0BdK3rLlCv3B240+cTrfqm+XSbHtpk+88aJtGwzyVK9QF/Xz8lBgE/oZZLN8nCTmOvxAZnszyxUuZ8GP8Cg==",
+      "version": "4.20240718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240718.0.tgz",
+      "integrity": "sha512-7RqxXIM9HyhjfZ9ztXjITuc7mL0w4s+zXgypqKmMuvuObC3DgXutJ3bOYbQ+Ss5QbywrzWSNMlmGdL/ldg/yZg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -2212,9 +2280,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.1.tgz",
-      "integrity": "sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -2621,9 +2689,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2770,15 +2838,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2832,7 +2898,6 @@
       "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -2872,7 +2937,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2889,7 +2953,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2906,7 +2969,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2923,7 +2985,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2940,7 +3001,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2957,7 +3017,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2974,7 +3033,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2991,7 +3049,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3008,7 +3065,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3025,7 +3081,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3042,7 +3097,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3059,7 +3113,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3076,7 +3129,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3093,7 +3145,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3110,7 +3161,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3127,7 +3177,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3144,7 +3193,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3505,7 +3553,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
       "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       },
@@ -3715,16 +3762,6 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4123,15 +4160,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4144,7 +4179,6 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5041,7 +5075,6 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
       "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "token-types": "^6.1.1"
@@ -5058,8 +5091,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "4.3.0",
@@ -5107,18 +5139,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5136,8 +5156,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -5154,7 +5173,8 @@
       "version": "20.4.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
       "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
@@ -5629,6 +5649,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -5659,17 +5680,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/astro/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/astro/node_modules/@workflow/swc-plugin": {
@@ -5735,6 +5745,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -5765,17 +5776,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/builders/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/builders/node_modules/@workflow/swc-plugin": {
@@ -5999,6 +5999,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6029,17 +6030,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/cli/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/cli/node_modules/@workflow/swc-plugin": {
@@ -6260,6 +6250,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6661,6 +6652,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6703,6 +6695,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6733,17 +6726,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/next/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/next/node_modules/@workflow/swc-plugin": {
@@ -6802,6 +6784,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6832,17 +6815,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/nitro/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/nitro/node_modules/@workflow/swc-plugin": {
@@ -6894,6 +6866,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6924,17 +6897,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/rollup/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/rollup/node_modules/@workflow/swc-plugin": {
@@ -6974,6 +6936,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -7004,17 +6967,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@workflow/sveltekit/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@workflow/sveltekit/node_modules/@workflow/swc-plugin": {
@@ -7190,6 +7142,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7261,6 +7214,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7270,7 +7224,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-8.0.1.tgz",
       "integrity": "sha512-toXuiWChyfOpEiCPsIw6HGHaNji5LVkvB6EREL548vGWr+hGaehwxG4LzN20vm9aGFXwnA/Jty8yW2/SmV+1zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "^21.3.0"
       },
@@ -7283,7 +7236,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-8.2.1.tgz",
       "integrity": "sha512-DNruLq+kalxcE7JeDxtqrN9kyWjLW8VqsQPLRTwD1t9ck/1rF4qBL0mX5Fe2/xLOMjo5wPb67BNX2kSAhzfLjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^9.6.1",
         "isexe": "^4.0.0"
@@ -7297,7 +7249,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
       "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -7324,7 +7275,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -7341,7 +7291,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -7351,7 +7300,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7364,7 +7312,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7377,7 +7324,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7387,7 +7333,6 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
       "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0",
         "unicorn-magic": "^0.3.0"
@@ -7404,7 +7349,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7417,7 +7361,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -7430,7 +7373,6 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7443,7 +7385,6 @@
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7456,7 +7397,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-14.2.3.tgz",
       "integrity": "sha512-F8Sr2O2aqwYfoXTafemRNAYDG4xwBTaHJpAo9YVnnnRXHLP9gkb+HYDsFoCAsCneS3/J7BOfeYnxxlUCicLqjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xhmikosr/bin-check": "^8.2.1",
         "@xhmikosr/downloader": "^16.1.2",
@@ -7472,7 +7412,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-11.1.2.tgz",
       "integrity": "sha512-f2hlnMN1ChbifAfdzWns6mssojjr3lgJm6MtT4ttVAClx85QEIQAdGXN22bPqy/qKxbvDf93GdqbR6+xIO/a4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xhmikosr/decompress-tar": "^9.0.1",
         "@xhmikosr/decompress-tarbz2": "^9.0.1",
@@ -7490,7 +7429,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-9.0.1.tgz",
       "integrity": "sha512-4AkVR1SoqTxYY22IRRYKDeLirPIDGqMqYsqgjKYuwhgRcBb+yDP4t5Xph33UCzL/nahK/aADmlMEjTNstbX7kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "^21.3.0",
         "is-stream": "^4.0.1",
@@ -7505,7 +7443,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7518,7 +7455,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-9.0.1.tgz",
       "integrity": "sha512-aFONnsbqEOuXudvK7V7wB8dcEAKR389oUYQfZhrQZA8OtogJpDjrUAvEH3Qlc9yFqTU6r5/svTEcRwtXhoIJbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xhmikosr/decompress-tar": "^9.0.0",
         "file-type": "^21.3.0",
@@ -7535,7 +7471,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7548,7 +7483,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-9.0.1.tgz",
       "integrity": "sha512-1JXu2b6yrpm5EuBoOzMU57B4qrHXJKWQQ7LlMynNEiz85mEjDciO3ayf//GXaTLLCEKiHjWlU3q3THjgf7uODA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xhmikosr/decompress-tar": "^9.0.0",
         "file-type": "^21.3.0",
@@ -7563,7 +7497,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7576,7 +7509,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-8.1.1.tgz",
       "integrity": "sha512-/B+Z0qJflGn5UEtmMZ2qeKeXwexOycxaibYhMOyLcRPJriXs4IkoSngVUVZXLYViu9TdHyFWynC6NB4EWBg8cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "^21.3.4",
         "get-stream": "^9.0.1",
@@ -7591,7 +7523,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -7608,7 +7539,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7621,7 +7551,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-16.1.2.tgz",
       "integrity": "sha512-31KQzQ6p4Rwnbo/gwTe4/Z+hVRcC8YoH/8f5xl+so1Oqqah5u1R3CGte8od+wOyNVfZ77DFijwy1umHk2NT6ZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xhmikosr/archive-type": "^8.0.1",
         "@xhmikosr/decompress": "^11.1.1",
@@ -7641,7 +7570,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7655,7 +7583,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -7672,7 +7599,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7685,7 +7611,6 @@
       "resolved": "https://registry.npmjs.org/@xhmikosr/os-filter-obj/-/os-filter-obj-4.0.0.tgz",
       "integrity": "sha512-CBJYipR5lrtQQZl9ylarWyh1qhcs/tMy9ydSHte/Hefn3ev8NMvS3ss+eqiXEoBr2wBVgKj2qjcViXO9P/8K4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "arch": "^3.0.0"
       },
@@ -7731,6 +7656,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7748,11 +7674,14 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7907,8 +7836,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -8574,7 +8502,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -8602,8 +8529,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -8620,7 +8546,6 @@
       "resolved": "https://registry.npmjs.org/binary-version/-/binary-version-7.1.0.tgz",
       "integrity": "sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^8.0.1",
         "find-versions": "^6.0.0"
@@ -8637,7 +8562,6 @@
       "resolved": "https://registry.npmjs.org/binary-version-check/-/binary-version-check-6.1.0.tgz",
       "integrity": "sha512-REKdLKmuViV2WrtWXvNSiPX04KbIjfUV3Cy8batUeOg+FtmowavzJorfFhWq95cVJzINnL/44ixP26TrdJZACA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "binary-version": "^7.1.0",
         "semver": "^7.6.0",
@@ -8655,7 +8579,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8668,7 +8591,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -8692,7 +8614,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -8705,7 +8626,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -8715,7 +8635,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -8950,6 +8869,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -8982,7 +8902,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -8993,7 +8912,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -9041,7 +8959,6 @@
       "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -9156,7 +9073,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -9166,7 +9082,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -9185,7 +9100,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -9202,7 +9116,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9753,7 +9666,6 @@
       "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
       "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9762,10 +9674,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9808,7 +9719,8 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -9860,7 +9772,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -10545,9 +10456,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.1.tgz",
-      "integrity": "sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -10558,35 +10469,35 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.1",
-        "@esbuild/android-arm": "0.20.1",
-        "@esbuild/android-arm64": "0.20.1",
-        "@esbuild/android-x64": "0.20.1",
-        "@esbuild/darwin-arm64": "0.20.1",
-        "@esbuild/darwin-x64": "0.20.1",
-        "@esbuild/freebsd-arm64": "0.20.1",
-        "@esbuild/freebsd-x64": "0.20.1",
-        "@esbuild/linux-arm": "0.20.1",
-        "@esbuild/linux-arm64": "0.20.1",
-        "@esbuild/linux-ia32": "0.20.1",
-        "@esbuild/linux-loong64": "0.20.1",
-        "@esbuild/linux-mips64el": "0.20.1",
-        "@esbuild/linux-ppc64": "0.20.1",
-        "@esbuild/linux-riscv64": "0.20.1",
-        "@esbuild/linux-s390x": "0.20.1",
-        "@esbuild/linux-x64": "0.20.1",
-        "@esbuild/netbsd-x64": "0.20.1",
-        "@esbuild/openbsd-x64": "0.20.1",
-        "@esbuild/sunos-x64": "0.20.1",
-        "@esbuild/win32-arm64": "0.20.1",
-        "@esbuild/win32-ia32": "0.20.1",
-        "@esbuild/win32-x64": "0.20.1"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.1.tgz",
-      "integrity": "sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
@@ -10601,9 +10512,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.1.tgz",
-      "integrity": "sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
@@ -10618,9 +10529,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.1.tgz",
-      "integrity": "sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
@@ -10635,9 +10546,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.1.tgz",
-      "integrity": "sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
@@ -10652,9 +10563,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.1.tgz",
-      "integrity": "sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
@@ -10669,9 +10580,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.1.tgz",
-      "integrity": "sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
@@ -10686,9 +10597,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.1.tgz",
-      "integrity": "sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
@@ -10703,9 +10614,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.1.tgz",
-      "integrity": "sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
@@ -10720,9 +10631,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.1.tgz",
-      "integrity": "sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
@@ -10737,9 +10648,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.1.tgz",
-      "integrity": "sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
@@ -10754,9 +10665,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.1.tgz",
-      "integrity": "sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
@@ -10771,9 +10682,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.1.tgz",
-      "integrity": "sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
@@ -10788,9 +10699,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.1.tgz",
-      "integrity": "sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
@@ -10805,9 +10716,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.1.tgz",
-      "integrity": "sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
@@ -10822,9 +10733,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.1.tgz",
-      "integrity": "sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
@@ -10839,9 +10750,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.1.tgz",
-      "integrity": "sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -10856,9 +10767,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
@@ -10873,9 +10784,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.1.tgz",
-      "integrity": "sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
@@ -10890,9 +10801,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.1.tgz",
-      "integrity": "sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
@@ -10907,9 +10818,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.1.tgz",
-      "integrity": "sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
@@ -10924,9 +10835,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.1.tgz",
-      "integrity": "sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
@@ -10941,9 +10852,9 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.1.tgz",
-      "integrity": "sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
@@ -10990,6 +10901,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -11070,6 +10982,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11154,6 +11067,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
       "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -11981,7 +11895,6 @@
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -12135,15 +12048,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -12176,7 +12080,6 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.28.0"
       },
@@ -12189,7 +12092,6 @@
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -12214,8 +12116,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.0",
@@ -12249,8 +12150,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -12304,7 +12204,6 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
       "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
       },
@@ -12332,7 +12231,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
       "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
         "strtok3": "^10.3.4",
@@ -12381,7 +12279,6 @@
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-4.0.0.tgz",
       "integrity": "sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -12394,7 +12291,6 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-7.0.1.tgz",
       "integrity": "sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "filename-reserved-regex": "^4.0.0"
       },
@@ -12471,7 +12367,6 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
       "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver-regex": "^4.0.5",
         "super-regex": "^1.0.0"
@@ -12663,7 +12558,6 @@
       "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
       "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -12948,7 +12842,6 @@
       "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
       "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^7.0.1",
         "byte-counter": "^0.1.0",
@@ -12975,7 +12868,6 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
       "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -12985,7 +12877,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -13102,8 +12993,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -13130,7 +13020,6 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -13202,8 +13091,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -13219,6 +13107,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
       "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -13286,7 +13175,6 @@
       "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
       "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       }
@@ -13591,7 +13479,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13788,7 +13675,6 @@
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13977,7 +13863,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -13987,7 +13872,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14070,7 +13954,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=13.2.0"
       }
@@ -14166,7 +14049,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -14200,7 +14082,6 @@
       "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
       "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-event": "^6.0.0",
         "type-fest": "^4.6.0",
@@ -14218,7 +14099,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -14340,7 +14220,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -14359,9 +14238,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240208.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240208.0.tgz",
-      "integrity": "sha512-NnP3MQFh2pV7iETNmJzSlMBF/KhRA+XT4A7JLCfxunadQSPbTMMgbsZo9EfLloMwHMUhZGNVot3Pvh+VnT2joQ==",
+      "version": "3.20240718.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240718.0.tgz",
+      "integrity": "sha512-TKgSeyqPBeT8TBLxbDJOKPWlq/wydoJRHjAyDdgxbw59N6wbP8JucK6AU1vXCfu21eKhrEin77ssXOpbfekzPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14372,11 +14251,11 @@
         "exit-hook": "^2.2.1",
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
-        "undici": "^5.28.2",
-        "workerd": "1.20240208.0",
-        "ws": "^8.11.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20240718.0",
+        "ws": "^8.17.1",
         "youch": "^3.2.2",
-        "zod": "^3.20.6"
+        "zod": "^3.22.3"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -14704,7 +14583,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -15236,6 +15114,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -15413,7 +15298,6 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
       "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -15423,7 +15307,6 @@
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
       "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-timeout": "^6.1.2"
       },
@@ -15469,7 +15352,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -15494,7 +15376,6 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -15512,16 +15393,18 @@
       }
     },
     "node_modules/partykit": {
-      "version": "0.0.93",
-      "resolved": "https://registry.npmjs.org/partykit/-/partykit-0.0.93.tgz",
-      "integrity": "sha512-5tepajS8bavUDVOdFlqn9uTPnJ9+cLIlVLoBGS+yD33CXgGfyml24E604XOtHVypmEhL7d/eHRlIzkvO6Vtr3Q==",
+      "version": "0.0.115",
+      "resolved": "https://registry.npmjs.org/partykit/-/partykit-0.0.115.tgz",
+      "integrity": "sha512-WHmJIZsAzRWrm1lrtU7wcl0tpD4rg2vgmn4+hXGPjU4mnXgFxyjVq2ZzO547xRXa1IbETOP6J9INl/ergR99bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cloudflare/workers-types": "4.20240222.0",
+        "@cloudflare/workers-types": "4.20240718.0",
         "clipboardy": "4.0.0",
-        "esbuild": "0.20.1",
-        "miniflare": "3.20240208.0",
+        "esbuild": "0.21.5",
+        "miniflare": "3.20240718.0",
+        "ts-dedent": "^2.2.0",
+        "unenv": "2.0.0-rc.0",
         "yoga-wasm-web": "0.3.3"
       },
       "bin": {
@@ -15619,7 +15502,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -15633,6 +15515,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
@@ -15648,8 +15537,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
@@ -15700,7 +15588,6 @@
       "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.9.2.tgz",
       "integrity": "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==",
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "@napi-rs/nice": "^1.0.1"
       }
@@ -15748,6 +15635,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15899,6 +15787,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15926,7 +15815,6 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -16072,7 +15960,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16119,6 +16006,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16131,6 +16019,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -16454,8 +16343,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -16492,7 +16380,6 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -16682,6 +16569,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -16770,7 +16658,6 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
       "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^6.0.0"
       },
@@ -16784,7 +16671,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -16803,7 +16689,6 @@
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
       "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16816,7 +16701,6 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-3.0.0.tgz",
       "integrity": "sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -16832,7 +16716,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -17073,7 +16956,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-plain-obj": "^1.0.0"
       },
@@ -17086,7 +16968,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sort-keys": "^1.0.0"
       },
@@ -17126,9 +17007,9 @@
       "license": "MIT"
     },
     "node_modules/stacktracey": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
-      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
@@ -17188,7 +17069,6 @@
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -17376,7 +17256,6 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-3.0.0.tgz",
       "integrity": "sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "inspect-with-kind": "^1.0.5",
         "is-plain-obj": "^1.1.0"
@@ -17437,7 +17316,6 @@
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
       "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
       },
@@ -17549,7 +17427,6 @@
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
       "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-timeout": "^1.0.1",
         "make-asynchronous": "^1.0.1",
@@ -17661,6 +17538,7 @@
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17724,7 +17602,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -17736,7 +17613,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -17782,7 +17658,6 @@
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -17792,7 +17667,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -17835,15 +17709,13 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/time-span": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
       "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "convert-hrtime": "^5.0.0"
       },
@@ -17906,6 +17778,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17978,7 +17851,6 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
       "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
@@ -18019,6 +17891,16 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -18049,6 +17931,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -18228,6 +18111,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18247,7 +18131,6 @@
       "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
       "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lukeed/csprng": "^1.0.0"
       },
@@ -18260,7 +18143,6 @@
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18288,7 +18170,6 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -18307,9 +18188,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18324,6 +18205,20 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.0.tgz",
+      "integrity": "sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.4",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -18530,18 +18425,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.21.0"
-      }
-    },
     "node_modules/vite-node/node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -18615,6 +18498,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18628,8 +18512,7 @@
       "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.3.3",
@@ -18712,6 +18595,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18896,6 +18780,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18909,6 +18794,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -19005,8 +18891,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -19185,9 +19070,9 @@
       "license": "MIT"
     },
     "node_modules/workerd": {
-      "version": "1.20240208.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240208.0.tgz",
-      "integrity": "sha512-edFdwHU95Ww2SmjBvBJhbc7hhVXMEo6Y7qqSWCl6W9lGScTlCMCXd4AU3f/EGJ3P++FC+CWqu+XuAywebbKF2Q==",
+      "version": "1.20240718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240718.0.tgz",
+      "integrity": "sha512-w7lOLRy0XecQTg/ujTLWBiJJuoQvzB3CdQ6/8Wgex3QxFhV9Pbnh3UbwIuUfMw3OCCPQc4o7y+1P+mISAgp6yg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -19198,11 +19083,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240208.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240208.0",
-        "@cloudflare/workerd-linux-64": "1.20240208.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240208.0",
-        "@cloudflare/workerd-windows-64": "1.20240208.0"
+        "@cloudflare/workerd-darwin-64": "1.20240718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240718.0",
+        "@cloudflare/workerd-linux-64": "1.20240718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240718.0",
+        "@cloudflare/workerd-windows-64": "1.20240718.0"
       }
     },
     "node_modules/workflow": {
@@ -19279,6 +19164,7 @@
       "integrity": "sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -19309,17 +19195,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/workflow/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/workflow/node_modules/@workflow/nest": {
@@ -19371,26 +19246,8 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/workflow/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/workflow/node_modules/commander": {
@@ -19398,7 +19255,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -19408,7 +19264,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -19431,7 +19286,6 @@
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -19445,7 +19299,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -19458,7 +19311,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19468,7 +19320,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -19573,9 +19424,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19725,7 +19576,6 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
       "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"
@@ -19751,7 +19601,6 @@
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -19767,13 +19616,13 @@
       "license": "MIT"
     },
     "node_modules/youch": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.3.tgz",
-      "integrity": "sha512-qSFXUk3UZBLfggAW3dJKg0BMblG5biqSF8M34E06o5CSsZtH92u9Hqmj2RzGiHDi64fhe83+4tENFP2DB6t6ZA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.1",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "autoprefixer": "^10.4.17",
     "concurrently": "^8.2.2",
     "nock": "^14.0.15",
-    "partykit": "0.0.93",
+    "partykit": "^0.0.115",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",


### PR DESCRIPTION
This PR adds the option to pick which videos you want to migrate instead of only being able to migrate all of them at once.

- If choose mode is selected, instead of migration starting immediately, available videos are fetched and displayed in a list where you can either upload them one by one or use row multi-select to upload multiple at once
- The list view has also been enhanced with video metadata like proper title, preview image, duration and link to source video for Vimeo source
- Errors now show for each failed upload separately and you can retry the upload
- Higher upload resolution options have been included if the video quality is Basic (not sure why this was limited since basic supports all resolutions with no extra upload cost)
- Partykit version has been bumped to latest, because the old version was throwing errors 